### PR TITLE
Bump version to 1.4.1 for correct npm publish

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "comapi-sdk-js-foundation",
     "description": "Comapi Javascript SDK - Foundation",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "keywords": [
         "messaging",
         "chat",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@comapi/sdk-js-foundation",
     "author": "Comapi",
     "description": "Comapi Javascript SDK - Foundation",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "main": "./src/index.js",
     "types": "./src/index.d.ts",
     "repository": {


### PR DESCRIPTION
@comapi/sdk-js-foundation@1.4.0 was accidentally published to npm from the comapi-sdk-js source repository instead of this bower distribution repository. This resulted in an incorrect package on npm containing:

Build tool devDependencies (grunt, webpack, karma, typescript) listed as runtime dependencies
Missing main and types fields
Wrong file structure
1.4.0 cannot be unpublished as other packages depend on it.

What this PR does
Bumps the npm package version to 1.4.1 so it can be correctly published from this repository. No code changes - the compiled files are identical to the 1.4.0 build.